### PR TITLE
Fix typo error on sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Usage
 ```
     import streamlit as st
-    import streamlit-gchart as gchart
+    import streamlit_gchart as gchart
     
     st.subheader("Bar Chart Demo")
 


### PR DESCRIPTION
Should use underscore, not dash.

Tested on python 3.11